### PR TITLE
Red Chapter 2: Observer Pattern

### DIFF
--- a/red/.classpath
+++ b/red/.classpath
@@ -2,5 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="C:/Program Files/Java/lib/lwjgl/jar/lwjgl.jar" sourcepath="C:/Program Files/Java/lib/lwjgl/src.zip"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/red/src/org/red/observer/Application.java
+++ b/red/src/org/red/observer/Application.java
@@ -1,0 +1,49 @@
+package org.red.observer;
+
+import org.lwjgl.opengl.GL11;
+import org.red.utils.gfx.GFXContext;
+
+/**
+ * Example of the Observer pattern. Observers respond to mouse updates
+ * to play back tones based on the X/Y coordinates of a GLFW window (a bit like a theremin),
+ * to alter the colour of the GL display based on the coordinates of the mouse, and
+ * report the mouse events to the console.
+ */
+public class Application {
+	private static final int WIDTH = 400, HEIGHT = 400;
+
+	public static void main(String[] args) {
+		GFXContext ctx = new GFXContext("Observer Pattern", WIDTH, HEIGHT);
+		Mouse mouse = new Mouse(ctx.getWindowRef());
+
+		// Create tones on X/Y coordinates
+		Theremin theremin = new Theremin(WIDTH, HEIGHT);
+		mouse.bind(theremin);
+
+		// Debug mouse events
+		mouse.bind(e -> {
+			switch(e.getType()) {
+			case CLICK:
+				System.out.printf( "Got click event for %d%n", e.getButton() );
+				break;
+			case MOVE:
+				System.out.printf("X [%04f], Y [%04f] %n", e.getMouse().getX(), e.getMouse().getY());
+				break;
+			case RELEASE:
+				System.out.printf( "Got release event for %d%n", e.getButton() );
+				break;
+			}
+		});
+
+		// Change colour of GL background on mouse coord
+		mouse.bind(e -> GL11.glClearColor(
+			(float) (e.getMouse().getX() / WIDTH),
+			0.f,
+			(float) (e.getMouse().getY() / HEIGHT),
+			0.f ));
+
+		new Thread(theremin).start();
+		ctx.run();
+		theremin.stop();
+	}
+}

--- a/red/src/org/red/observer/Mouse.java
+++ b/red/src/org/red/observer/Mouse.java
@@ -1,0 +1,80 @@
+package org.red.observer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.glfw.GLFWCursorPosCallback;
+import org.lwjgl.glfw.GLFWMouseButtonCallback;
+import org.red.observer.MouseEvent.Type;
+
+/**
+ * Awaits mouse updates from GLFW, forms them into events that can
+ * be monitored by multiple observers.
+ */
+public class Mouse implements Observable<MouseEvent> {
+	private List<Observer<MouseEvent>> observers = new ArrayList<>();
+	private double x, y;
+	private Map<Integer, Boolean> buttonState = new HashMap<>();
+
+	public Mouse(long window) {
+		// As it happens, the GLFW callbacks are abstract classes, so this can't
+		// implement them directly in the outer type
+		GLFW.glfwSetCursorPosCallback(window, new GLFWCursorPosCallback() {
+			@Override
+			public void invoke(long window, double xpos, double ypos) {
+				Mouse.this.setCursorPos(xpos, ypos);
+			}
+		});
+
+		GLFW.glfwSetMouseButtonCallback(window, new GLFWMouseButtonCallback() {
+			@Override
+			public void invoke(long window, int button, int action, int mods) {
+				Mouse.this.setMouseButton(button, action);
+			}
+		});
+	}
+	
+	@Override
+	public Mouse bind(Observer<MouseEvent> observer) {
+		observers.add(observer);
+		return this;
+	}
+
+	@Override
+	public Mouse unbind(Observer<MouseEvent> observer) {
+		observers.remove(observer);
+		return this;
+	}
+
+	public Mouse setCursorPos(double x, double y) {
+		this.x = x;
+		this.y = y;
+		notify( new MouseEvent( Type.MOVE, this ) );
+		return this;
+	}
+
+	public Mouse setMouseButton(int button, int action) {
+		this.buttonState.put( button, action == GLFW.GLFW_PRESS );
+		notify( new MouseEvent( action == GLFW.GLFW_PRESS ? Type.CLICK : Type.RELEASE, this, button ) );
+		return this;
+	}
+
+	public double getX() {
+		return x;
+	}
+
+	public double getY() {
+		return y;
+	}
+
+	public boolean isHeld(int button) {
+		return buttonState.containsKey(button) && buttonState.get(button);
+	}
+
+	private void notify(MouseEvent event) {
+		observers.forEach(o -> o.onEvent(event));
+	}
+}

--- a/red/src/org/red/observer/MouseEvent.java
+++ b/red/src/org/red/observer/MouseEvent.java
@@ -1,0 +1,38 @@
+package org.red.observer;
+
+/**
+ * Mouse state change events. This maintains the reference
+ * to the underlying (observed) mouse so that further state
+ * can be obtained there.
+ */
+public class MouseEvent {
+	public static enum Type {
+		CLICK, RELEASE, MOVE
+	}
+
+	private final Type type;
+	private final Mouse mouse;
+	private final int button;
+
+	public MouseEvent(Type type, Mouse mouse) {
+		this(type, mouse, -1);
+	}
+
+	public MouseEvent(Type type, Mouse mouse, int button) {
+		this.type = type;
+		this.mouse = mouse;
+		this.button = button;
+	}
+
+	public Type getType() {
+		return type;
+	}
+
+	public Mouse getMouse() {
+		return mouse;
+	}
+
+	public int getButton() {
+		return button;
+	}
+}

--- a/red/src/org/red/observer/Observable.java
+++ b/red/src/org/red/observer/Observable.java
@@ -1,0 +1,12 @@
+package org.red.observer;
+
+/**
+ * Types which permit binding/unbinding on observers that await
+ * updates on changes to the state of this type.
+ *
+ * @param <T> event type for notifications
+ */
+public interface Observable<T> {
+	Observable<T> bind(Observer<T> observer);
+	Observable<T> unbind(Observer<T> observer);
+}

--- a/red/src/org/red/observer/Observer.java
+++ b/red/src/org/red/observer/Observer.java
@@ -1,0 +1,12 @@
+package org.red.observer;
+
+/**
+ * Simple interface for observers that await updates from some
+ * subject.
+ *
+ * @param <T> event type for push notification
+ */
+@FunctionalInterface
+public interface Observer<T> {
+	void onEvent( T event );
+}

--- a/red/src/org/red/observer/Theremin.java
+++ b/red/src/org/red/observer/Theremin.java
@@ -1,0 +1,84 @@
+package org.red.observer;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.sound.sampled.Mixer;
+
+import org.lwjgl.glfw.GLFW;
+import org.red.strategy.Oscillator;
+import org.red.strategy.SineWave;
+import org.red.strategy.WaveformAlgorithm;
+import org.red.utils.au.ChannelMixer;
+import org.red.utils.au.MixerUtils;
+
+/**
+ * It's a theremin! Kind of...
+ * Updates the tone of oscillators based on the X and Y position
+ * of mouse, plays the tone back when the left mouse button is
+ * pressed down.
+ */
+public class Theremin implements Observer<MouseEvent>, Runnable {
+	private Oscillator a, b;
+	private ChannelMixer channel;
+	private final float scaleA, scaleB;
+	private AtomicBoolean
+		play = new AtomicBoolean(false),
+		running = new AtomicBoolean(true);
+
+	public Theremin(float canvasX, float canvasY) {
+		Mixer mix = MixerUtils.defaultMixer();
+		channel = MixerUtils.channel(mix);
+
+		WaveformAlgorithm wave = new SineWave();
+		a = new Oscillator().setWaveform(wave);
+		b = new Oscillator().setWaveform(wave);
+
+		channel
+			.register(a)
+			.register(b);
+
+		scaleA = 1200 / canvasX;
+		scaleB = 1200 / canvasY;
+	}
+
+	@Override
+	public void run() {
+		while ( running.get() ) {
+			if ( play.get() ) {
+				channel.tick();
+			}
+		}
+	}
+
+	public void stop() {
+		running.set(false);
+	}
+
+	@Override
+	public void onEvent(MouseEvent event) {
+		switch( event.getType() ) {
+		case CLICK:
+			if ( event.getButton() == GLFW.GLFW_MOUSE_BUTTON_LEFT )
+				play.set(true);
+			break;
+
+		case RELEASE:
+			if ( event.getButton() == GLFW.GLFW_MOUSE_BUTTON_LEFT )
+				play.set(false);
+			break;
+
+		case MOVE:
+			updateFreqFromCanvas(
+				(float) event.getMouse().getX(),
+				(float) event.getMouse().getY());
+			break;		
+		}
+	}
+
+	private synchronized void updateFreqFromCanvas(float x, float y) {
+		float aFreq = x * scaleA;
+		float bFreq = y * scaleB;
+		a.setFrequency(aFreq < 0.f ? 0.f : aFreq);
+		b.setFrequency(bFreq < 0.f ? 0.f : bFreq);
+	}
+}

--- a/red/src/org/red/utils/gfx/GFXContext.java
+++ b/red/src/org/red/utils/gfx/GFXContext.java
@@ -1,0 +1,49 @@
+package org.red.utils.gfx;
+
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.system.MemoryUtil;
+
+/**
+ * Simplified GLFW windowing/event looping. At some point this should
+ * be extended to allow per-frame drawing.
+ */
+public class GFXContext implements Runnable {
+	private final long window;
+
+	public GFXContext(String title, int w, int h) {
+		if ( GLFW.glfwInit() != GLFW.GLFW_TRUE )
+			throw new IllegalStateException("Unable to initialise GLFW");
+		
+		window = GLFW.glfwCreateWindow(w, h, title, MemoryUtil.NULL, MemoryUtil.NULL);
+		if ( window == MemoryUtil.NULL )
+			throw new IllegalStateException("Failed to create window");
+
+		GLFW.glfwMakeContextCurrent(window);
+		GLFW.glfwSwapInterval(1);
+		GLFW.glfwShowWindow(window);
+	}
+
+	public long getWindowRef() {
+		return window;
+	}
+
+	@Override
+	public void run() {
+		try {
+			GL.createCapabilities();
+			GL11.glClearColor(0.f, 0.f, 0.f, 0.f);
+
+			while( GLFW.glfwWindowShouldClose(window) == GLFW.GLFW_FALSE ) {
+				GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT );
+				GLFW.glfwSwapBuffers(window);
+				GLFW.glfwPollEvents();
+			}
+
+			GLFW.glfwDestroyWindow(window);
+		} finally {
+			GLFW.glfwTerminate();
+		}
+	}
+}


### PR DESCRIPTION
This chapter: messing around with the LWJGL to get at Java GL and GLFW bindings. Requires system property `-Djava.library.path` to point at the directory containing native files for LWJGL.