### PR TITLE
axp - Chapter 10 - The State Pattern

### DIFF
--- a/axp-test/org/axp/state/RunClient.java
+++ b/axp-test/org/axp/state/RunClient.java
@@ -3,8 +3,11 @@ package org.axp.state;
 import org.axp.state.ui.ClientView;
 import org.xml.sax.InputSource;
 
-public class RunGame {
-
+/**
+ * Run the client against standard input. Try typing in lines from <tt>test.xml</tt>, and users and games
+ * should appear.
+ */
+public class RunClient {
 	public static void main( String...args ) {
 		GameEventController controller = new GameEventController();
 		ClientView ui = new ClientView( controller );

--- a/axp-test/org/axp/state/RunGame.java
+++ b/axp-test/org/axp/state/RunGame.java
@@ -1,0 +1,21 @@
+package org.axp.state;
+
+import org.axp.state.ui.ClientView;
+import org.xml.sax.InputSource;
+
+public class RunGame {
+
+	public static void main( String...args ) {
+		GameEventController controller = new GameEventController();
+		ClientView ui = new ClientView( controller );
+		controller.addObserver( ui );
+		ui.setVisible( true );
+		
+		try {
+			controller.parse( new InputSource( System.in ) );
+		}
+		catch ( Exception e ) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/axp-test/org/axp/state/test.xml
+++ b/axp-test/org/axp/state/test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<channel>
+	<user id="p1">Alice Aqua</user>
+	<user id="p2">Bob Brown</user>
+	<user id="p3">Carol Chartreuse</user>
+	<user id="p4">Dave Dandelion</user>
+	<user id="p5">Eve Emerald</user>
+	<game id="g1" type="chess">
+		<player id="p1"/>
+		<player id="p4"/>
+		<rule name="secondsPerMove" setting="30"/>
+		<rule name="totalTimeMinutes" setting="15"/> 
+	</game>
+	<user id="p6">Fred Fuschia</user>
+	<logoff id="p5"/>
+	<game id="g2" type="hearts">
+		<player id="p2"/>
+		<player id="p3"/>
+		<player id="p6"/>
+		<player id="p4"/>
+		<rule name="jackDiamonds" setting="on"/>
+	</game>
+	<finishGame id="g1" winner="p1"/>
+	<logoff id="p1"/>
+	<finishGame id="g2" winner="p6"/>
+</channel>

--- a/axp/org/axp/state/GameEventController.java
+++ b/axp/org/axp/state/GameEventController.java
@@ -1,0 +1,103 @@
+package org.axp.state;
+
+import java.io.IOException;
+import java.util.Observable;
+import java.util.TreeMap;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.axp.state.entity.Game;
+import org.axp.state.states.InitialState;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+public class GameEventController extends Observable {
+	private XMLReader xmlReader;
+	
+	private TreeMap<String, String> users = new TreeMap<>();
+	private TreeMap<String, Game> games = new TreeMap<>();
+	
+	public void parse( InputSource source ) throws ParserConfigurationException, SAXException, IOException {
+		SAXParserFactory factory = SAXParserFactory.newInstance(); 
+		SAXParser saxParser = factory.newSAXParser();
+		this.xmlReader = saxParser.getXMLReader();
+		
+		setState( new InitialState( this ) );
+		this.xmlReader.parse( source );
+	}
+	
+	private void notifyUi( String changed ) {
+		setChanged();
+		notifyObservers( changed );
+	}
+	
+	public void setState( XMLState state ) {
+		notifyUi( "STATE:" + state.getClass().getSimpleName() );
+		this.xmlReader.setContentHandler( state );
+	}
+	
+	public void connect() {
+		notifyUi( "CONNECTED" );
+	}
+	
+	public void disconnect() {
+		notifyUi( "DISCONNECTED" );
+	}
+	
+	public void finish() {
+		notifyUi( "FINISHED" );
+	}
+	
+	public void updateUsers() {
+		notifyUi( "USERS" );
+	}
+
+	public void addUser( String userId, String userName ) {
+		this.users.put( userId, userName );
+		updateUsers();
+	}
+
+	public void removeUser( String userId ) {
+		String user = this.users.remove( userId );
+		
+		if ( user == null ) {
+			throw new IllegalArgumentException( "No user with id " + userId );
+		}
+		
+		updateUsers();
+	}
+
+	public String[] getUserList() {
+		return this.users.values().toArray( new String[] {} );
+	}
+
+	public String getUser( String userId ) {
+		return this.users.get( userId );
+	}
+	
+	public void updateGames() {
+		notifyUi( "GAMES" );
+	}
+
+	public void addGame( String gameId, Game game ) {
+		this.games.put( gameId, game );
+		updateGames();
+	}
+
+	public void removeGame( String gameId ) {
+		Game game = this.games.remove( gameId );
+		
+		if ( game == null ) {
+			throw new IllegalArgumentException( "No game with id " + gameId );
+		}
+		
+		updateGames();
+	}
+
+	public Game[] getGameList() {
+		return this.games.values().toArray( new Game[] {} );
+	}
+}

--- a/axp/org/axp/state/GameEventController.java
+++ b/axp/org/axp/state/GameEventController.java
@@ -87,13 +87,24 @@ public class GameEventController extends Observable {
 		updateGames();
 	}
 
-	public void removeGame( String gameId ) {
-		Game game = this.games.remove( gameId );
+	public void finishGame( String gameId, String winnerId ) {
+		Game game = this.games.get( gameId );
 		
 		if ( game == null ) {
 			throw new IllegalArgumentException( "No game with id " + gameId );
 		}
 		
+		String winner = null;
+		
+		if ( winnerId != null ) {
+			winner = this.users.get( winnerId );
+			
+			if ( winner == null ) {
+				throw new IllegalArgumentException( "No player with id " + winnerId );
+			}
+		}
+		
+		game.setFinished( winner );
 		updateGames();
 	}
 

--- a/axp/org/axp/state/GameEventController.java
+++ b/axp/org/axp/state/GameEventController.java
@@ -14,12 +14,29 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
+/**
+ * This is the main client that parses a stream of XML using the SAX Parser. In State Pattern terms, this
+ * is the <em>Context</em> class; the {@link XMLState} class is the main <em>State</em> interface (actually
+ * an abstract class), and each of the classes in the <tt>org.axp.state.states</tt> package is a
+ * <em>Concrete State</em>.
+ * 
+ * Each of the states is also a {@link ContentHandler}; the SAX {@link XMLReader} allows these to be swapped
+ * in and out as necessary, making it ideal for adaption to the state pattern.
+ */
 public class GameEventController extends Observable {
 	private XMLReader xmlReader;
 	
 	private TreeMap<String, String> users = new TreeMap<>();
 	private TreeMap<String, Game> games = new TreeMap<>();
 	
+	/**
+	 * Parse an XML document
+	 * 
+	 * @param source any input source; e.g. an open file or <tt>System.in</tt>
+	 * @throws ParserConfigurationException hopefully never
+	 * @throws SAXException if the XML document was malformed
+	 * @throws IOException if the input source could not be read
+	 */
 	public void parse( InputSource source ) throws ParserConfigurationException, SAXException, IOException {
 		SAXParserFactory factory = SAXParserFactory.newInstance(); 
 		SAXParser saxParser = factory.newSAXParser();
@@ -29,37 +46,58 @@ public class GameEventController extends Observable {
 		this.xmlReader.parse( source );
 	}
 	
+	/**
+	 * Notify all observers of some change
+	 * @param changed a string describing the change
+	 */
 	private void notifyUi( String changed ) {
 		setChanged();
 		notifyObservers( changed );
 	}
 	
+	/**
+	 * Enter a new parse state
+	 * @param state
+	 */
 	public void setState( XMLState state ) {
 		notifyUi( "STATE:" + state.getClass().getSimpleName() );
 		this.xmlReader.setContentHandler( state );
 	}
 	
+	/** Connected to server - notify observers */
 	public void connect() {
 		notifyUi( "CONNECTED" );
 	}
 	
+	/** Disconnected from server - notify observers */
 	public void disconnect() {
 		notifyUi( "DISCONNECTED" );
 	}
 	
+	/** Finished parsing - notify observers */
 	public void finish() {
 		notifyUi( "FINISHED" );
 	}
 	
+	/** List of users has changed - notify observers */
 	public void updateUsers() {
 		notifyUi( "USERS" );
 	}
 
+	/**
+	 * Add a new user to the list
+	 * @param userId internal ID
+	 * @param userName display name
+	 */
 	public void addUser( String userId, String userName ) {
 		this.users.put( userId, userName );
 		updateUsers();
 	}
 
+	/**
+	 * Remove an existing user after logoff
+	 * @param userId internal ID
+	 */
 	public void removeUser( String userId ) {
 		String user = this.users.remove( userId );
 		
@@ -70,23 +108,43 @@ public class GameEventController extends Observable {
 		updateUsers();
 	}
 
+	/**
+	 * Get a list of current user names
+	 * @return array of display names
+	 */
 	public String[] getUserList() {
 		return this.users.values().toArray( new String[] {} );
 	}
 
+	/**
+	 * Get a specific user's name
+	 * @param userId internal ID
+	 * @return user's display name
+	 */
 	public String getUser( String userId ) {
 		return this.users.get( userId );
 	}
 	
+	/** List of games has changed - notify observers */
 	public void updateGames() {
 		notifyUi( "GAMES" );
 	}
 
+	/**
+	 * Add a new game to the list
+	 * @param gameId internal ID
+	 * @param game game details
+	 */
 	public void addGame( String gameId, Game game ) {
 		this.games.put( gameId, game );
 		updateGames();
 	}
 
+	/**
+	 * Mark a game as finished
+	 * @param gameId internal ID
+	 * @param winnerId winner of the game, or null if tied
+	 */
 	public void finishGame( String gameId, String winnerId ) {
 		Game game = this.games.get( gameId );
 		
@@ -108,6 +166,10 @@ public class GameEventController extends Observable {
 		updateGames();
 	}
 
+	/**
+	 * Get a list of current and finished games
+	 * @return array of {@link Game} objects
+	 */
 	public Game[] getGameList() {
 		return this.games.values().toArray( new Game[] {} );
 	}

--- a/axp/org/axp/state/XMLState.java
+++ b/axp/org/axp/state/XMLState.java
@@ -3,13 +3,33 @@ package org.axp.state;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
 
+/**
+ * A parse state. Having multiple states allows the parser to (roughly) meet the Single Responsibility
+ * Principle; one class for parsing users, another for parsing games, and so on. It also reduces the
+ * amount of internal state we have to store, e.g. anything involving stacks of tags, which quickly
+ * becomes a headache.
+ * 
+ * We subclass {@link DefaultHandler} in order to have the standard SAX XML-handling methods available
+ * to each state.
+ */
 public abstract class XMLState extends DefaultHandler {
 	protected final GameEventController controller;
 	
+	/**
+	 * Construct against a particular context
+	 * @param controller the main controller which handles the parsing
+	 */
 	public XMLState( GameEventController controller ) {
 		this.controller = controller;
 	}
 	
+	/**
+	 * Convenience method to assert that an attribute exists and then get its value
+	 * @param elementName the element currently being parsed
+	 * @param attr the attribute key to get
+	 * @param attributes the collection of attributes
+	 * @return the value corresponding to <tt>attr</tt>
+	 */
 	protected static String getAttr( String elementName, String attr, Attributes attributes ) {
 		if ( attributes == null || attributes.getValue( attr ) == null ) {
 			throw new IllegalArgumentException( elementName + " without " + attr + '!' );
@@ -22,6 +42,7 @@ public abstract class XMLState extends DefaultHandler {
 		return getAttr( elementName, "id", attributes );
 	}
 	
+	/* Handle character data */
 	@Override
 	public void characters( char[] ch, int start, int length ) {
 		String content = new String( ch, start, length ).trim();
@@ -31,22 +52,26 @@ public abstract class XMLState extends DefaultHandler {
 		}
 	}
 	
+	/* End of document, after final closing tag */
 	@Override
 	public void endDocument() {
 		System.err.println( "Unexpected end of document" );
 		controller.finish();
 	}
 	
+	/* End tag of an element */
 	@Override
 	public void endElement( String uri, String localName, String qName ) {
 		throw new IllegalStateException( "Not expecting end of element " + qName + " in this location" );
 	}
 	
+	/* Start of document, before first opening tag */
 	@Override
 	public void startDocument() {
 		throw new IllegalStateException( "Unexpected start of document" );
 	}
 	
+	/* Start tag of an element */
 	@Override
 	public void startElement( String uri, String localName, String qName, Attributes attributes ) {
 		throw new IllegalStateException( "Not expecting start of element " + qName + " in this location" );

--- a/axp/org/axp/state/XMLState.java
+++ b/axp/org/axp/state/XMLState.java
@@ -1,0 +1,54 @@
+package org.axp.state;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.DefaultHandler;
+
+public abstract class XMLState extends DefaultHandler {
+	protected final GameEventController controller;
+	
+	public XMLState( GameEventController controller ) {
+		this.controller = controller;
+	}
+	
+	protected static String getAttr( String elementName, String attr, Attributes attributes ) {
+		if ( attributes == null || attributes.getValue( attr ) == null ) {
+			throw new IllegalArgumentException( elementName + " without " + attr + '!' );
+		}
+		
+		return attributes.getValue( attr );
+	}
+	
+	protected static String getId( String elementName, Attributes attributes ) {
+		return getAttr( elementName, "id", attributes );
+	}
+	
+	@Override
+	public void characters( char[] ch, int start, int length ) {
+		String content = new String( ch, start, length ).trim();
+		
+		if ( !"".equals( content ) ) {
+			throw new IllegalStateException( "Not expecting character content (" + content + ") in this location" );
+		}
+	}
+	
+	@Override
+	public void endDocument() {
+		System.err.println( "Unexpected end of document" );
+		controller.finish();
+	}
+	
+	@Override
+	public void endElement( String uri, String localName, String qName ) {
+		throw new IllegalStateException( "Not expecting end of element " + qName + " in this location" );
+	}
+	
+	@Override
+	public void startDocument() {
+		throw new IllegalStateException( "Unexpected start of document" );
+	}
+	
+	@Override
+	public void startElement( String uri, String localName, String qName, Attributes attributes ) {
+		throw new IllegalStateException( "Not expecting start of element " + qName + " in this location" );
+	}
+}

--- a/axp/org/axp/state/entity/Game.java
+++ b/axp/org/axp/state/entity/Game.java
@@ -7,6 +7,8 @@ public class Game {
 	private String gameType;
 	private ArrayList<String> players = new ArrayList<>();
 	private TreeMap<String,String> rules = new TreeMap<>();
+	private boolean finished;
+	private String winner;
 	
 	public Game( String gameType ) {
 		this.gameType = gameType;
@@ -17,6 +19,10 @@ public class Game {
 		
 		for ( String p : this.players ) {
 			sb.append( "\n\t" ).append( p );
+			
+			if ( p.equals( this.winner ) ) {
+				sb.append( " *" );
+			}
 		}
 		
 		for ( String rule : this.rules.keySet() ) {
@@ -51,5 +57,18 @@ public class Game {
 		}
 		
 		return ruleList;
+	}
+	
+	public boolean isFinished() {
+		return this.finished;
+	}
+	
+	public String getWinner() {
+		return this.winner;
+	}
+	
+	public void setFinished( String winner ) {
+		this.finished = true;
+		this.winner = winner;
 	}
 }

--- a/axp/org/axp/state/entity/Game.java
+++ b/axp/org/axp/state/entity/Game.java
@@ -1,0 +1,55 @@
+package org.axp.state.entity;
+
+import java.util.ArrayList;
+import java.util.TreeMap;
+
+public class Game {
+	private String gameType;
+	private ArrayList<String> players = new ArrayList<>();
+	private TreeMap<String,String> rules = new TreeMap<>();
+	
+	public Game( String gameType ) {
+		this.gameType = gameType;
+	}
+	
+	public String toString() {
+		StringBuilder sb = new StringBuilder( this.gameType );
+		
+		for ( String p : this.players ) {
+			sb.append( "\n\t" ).append( p );
+		}
+		
+		for ( String rule : this.rules.keySet() ) {
+			sb.append( "\n\t" ).append( rule ).append( " = " ).append( this.rules.get( rule ) );
+		}
+		
+		return sb.toString();
+	}
+
+	public void addPlayer( String player ) {
+		this.players.add( player );
+	}
+	
+	public void addRule( String ruleName, String value ) {
+		this.rules.put( ruleName, value);
+	}
+
+	public String getGameType() {
+		return this.gameType;
+	}
+	
+	public String[] getPlayers() {
+		return this.players.toArray( new String[] {} );
+	}
+	
+	public String[] getRules() {
+		String[] ruleList = new String[ this.rules.size() ];
+		int idx = 0;
+		
+		for ( String r : this.rules.keySet() ) {
+			ruleList[idx++] = r + " = " + this.rules.get( r );
+		}
+		
+		return ruleList;
+	}
+}

--- a/axp/org/axp/state/entity/Game.java
+++ b/axp/org/axp/state/entity/Game.java
@@ -3,6 +3,10 @@ package org.axp.state.entity;
 import java.util.ArrayList;
 import java.util.TreeMap;
 
+/**
+ * An entity representing the state of some game on the server. We see who's playing, some rule variations,
+ * and if it is finished. (And if so, who won).
+ */
 public class Game {
 	private String gameType;
 	private ArrayList<String> players = new ArrayList<>();

--- a/axp/org/axp/state/states/FinalState.java
+++ b/axp/org/axp/state/states/FinalState.java
@@ -3,6 +3,10 @@ package org.axp.state.states;
 import org.axp.state.GameEventController;
 import org.axp.state.XMLState;
 
+/**
+ * Final state of the XML parser; we've seen the end &lt;/channel*gt; tag, and are just
+ * awaiting the document end.
+ */
 public class FinalState extends XMLState {
 	public FinalState( GameEventController controller ) {
 		super( controller );

--- a/axp/org/axp/state/states/FinalState.java
+++ b/axp/org/axp/state/states/FinalState.java
@@ -1,0 +1,15 @@
+package org.axp.state.states;
+
+import org.axp.state.GameEventController;
+import org.axp.state.XMLState;
+
+public class FinalState extends XMLState {
+	public FinalState( GameEventController controller ) {
+		super( controller );
+	}
+	
+	@Override
+	public void endDocument() {
+		controller.finish();
+	}
+}

--- a/axp/org/axp/state/states/GameState.java
+++ b/axp/org/axp/state/states/GameState.java
@@ -5,6 +5,11 @@ import org.axp.state.XMLState;
 import org.axp.state.entity.Game;
 import org.xml.sax.Attributes;
 
+/**
+ * Game details state of the XML parser. Here we process &lt;player/&gt; and &lt;rule/&gt; tags that
+ * modify the current game; we apply these to the {@link Game} entity and tell the controller to
+ * refresh. When we see the end &lt;/game&gt; tag, we return to {@link ReadyState}.
+ */
 public class GameState extends XMLState {
 	private Game game;
 	

--- a/axp/org/axp/state/states/GameState.java
+++ b/axp/org/axp/state/states/GameState.java
@@ -1,0 +1,45 @@
+package org.axp.state.states;
+
+import org.axp.state.GameEventController;
+import org.axp.state.XMLState;
+import org.axp.state.entity.Game;
+import org.xml.sax.Attributes;
+
+public class GameState extends XMLState {
+	private Game game;
+	
+	public GameState( GameEventController controller, Game game ) {
+		super( controller );
+		this.game = game;
+	}
+	@Override
+	public void startElement( String uri, String localName, String qName, Attributes attributes ) {
+		if ( "player".equals( qName ) ) {
+			String userId = getId( "Player", attributes );
+			this.game.addPlayer( controller.getUser( userId ) );
+			this.controller.updateGames();
+		}
+		else if ( "rule".equals( qName ) ) {
+			String ruleName = getAttr( "Rule", "name", attributes );
+			String setting = getAttr( "Rule", "setting", attributes );
+			this.game.addRule( ruleName, setting );
+			this.controller.updateGames();
+		}
+		else {
+			super.startElement( uri, localName, qName, attributes );
+		}
+	}
+	
+	@Override
+	public void endElement( String uri, String localName, String qName ) {
+		if ( "game".equals( qName ) ) {
+			controller.setState( new ReadyState( controller ) );
+		}
+		else if ( "player".equals( qName ) || "rule".equals( qName ) ) {
+			/* Ignore end of player/rule elements */
+		}
+		else {
+			super.endElement( uri, localName, qName );
+		}
+	}
+}

--- a/axp/org/axp/state/states/InitialState.java
+++ b/axp/org/axp/state/states/InitialState.java
@@ -4,6 +4,10 @@ import org.axp.state.GameEventController;
 import org.axp.state.XMLState;
 import org.xml.sax.Attributes;
 
+/**
+ * Initial state of the XML parser. We wait around for the first &lt;channel&gt; start tag, and then
+ * move into the {@link ReadyState}.
+ */
 public class InitialState extends XMLState {
 	public InitialState( GameEventController controller ) {
 		super( controller );

--- a/axp/org/axp/state/states/InitialState.java
+++ b/axp/org/axp/state/states/InitialState.java
@@ -1,0 +1,27 @@
+package org.axp.state.states;
+
+import org.axp.state.GameEventController;
+import org.axp.state.XMLState;
+import org.xml.sax.Attributes;
+
+public class InitialState extends XMLState {
+	public InitialState( GameEventController controller ) {
+		super( controller );
+	}
+	
+	@Override
+	public void startDocument() {
+		/* We allow this, but don't change state until we actually see the root element */
+	}
+	
+	@Override
+	public void startElement( String uri, String localName, String qName, Attributes attributes ) {
+		if ( "channel".equals( qName ) ) {
+			controller.connect();
+			controller.setState( new ReadyState( controller ) );
+		}
+		else {
+			super.startElement( uri, localName, qName, attributes );
+		}
+	}
+}

--- a/axp/org/axp/state/states/ReadyState.java
+++ b/axp/org/axp/state/states/ReadyState.java
@@ -28,7 +28,8 @@ public class ReadyState extends XMLState {
 		}
 		else if ( "finishGame".equals( qName ) ) {
 			String gameId = getId( "Finish game", attributes );
-			controller.removeGame( gameId );
+			String winner = attributes.getValue( "winner" );
+			controller.finishGame( gameId, winner );
 		}
 		else {
 			super.startElement( uri, localName, qName, attributes );

--- a/axp/org/axp/state/states/ReadyState.java
+++ b/axp/org/axp/state/states/ReadyState.java
@@ -1,0 +1,51 @@
+package org.axp.state.states;
+
+import org.axp.state.GameEventController;
+import org.axp.state.XMLState;
+import org.axp.state.entity.Game;
+import org.xml.sax.Attributes;
+
+public class ReadyState extends XMLState {
+	public ReadyState( GameEventController controller ) {
+		super( controller );
+	}
+	
+	@Override
+	public void startElement( String uri, String localName, String qName, Attributes attributes ) {
+		if ( "user".equals( qName ) ) {
+			String userId = getId( "User", attributes );
+			controller.setState( new UserState( controller, userId ) );
+		}
+		else if ( "logoff".equals( qName ) ) {
+			String userId = getId( "Log off", attributes );
+			controller.removeUser( userId );
+		}
+		else if ( "game".equals( qName ) ) {
+			String gameId = getId( "Game", attributes );
+			Game game = new Game( getAttr( "Game", "type", attributes ) );
+			controller.addGame( gameId, game );
+			controller.setState( new GameState( controller, game ) );
+		}
+		else if ( "finishGame".equals( qName ) ) {
+			String gameId = getId( "Finish game", attributes );
+			controller.removeGame( gameId );
+		}
+		else {
+			super.startElement( uri, localName, qName, attributes );
+		}
+	}
+
+	@Override
+	public void endElement( String uri, String localName, String qName ) {
+		if ( "channel".equals( qName ) ) {
+			controller.disconnect();
+			controller.setState( new FinalState( controller ) );
+		}
+		else if ( "logoff".equals( qName ) || "finishGame".equals( qName ) ) {
+			/* Ignore end of logoff/finishGame elements */
+		}
+		else {
+			super.endElement( uri, localName, qName );
+		}
+	}
+}

--- a/axp/org/axp/state/states/ReadyState.java
+++ b/axp/org/axp/state/states/ReadyState.java
@@ -5,6 +5,13 @@ import org.axp.state.XMLState;
 import org.axp.state.entity.Game;
 import org.xml.sax.Attributes;
 
+/**
+ * This is the main state of the XML parser. We wait for users to log in (&lt;user&gt;) and out
+ * (&lt;logoff/&gt;) and for games to be created (&lt;game&gt;) and finish (&lt;finishGame/&gt;),
+ * moving into the {@link UserState} and {@link GameState} respectively.
+ * 
+ * Once we finally see the end &lt;/channel&gt; element, we disconnect and move to the {@link FinalState}.
+ */
 public class ReadyState extends XMLState {
 	public ReadyState( GameEventController controller ) {
 		super( controller );

--- a/axp/org/axp/state/states/UserState.java
+++ b/axp/org/axp/state/states/UserState.java
@@ -1,0 +1,34 @@
+package org.axp.state.states;
+
+import org.axp.state.GameEventController;
+import org.axp.state.XMLState;
+
+public class UserState extends XMLState {
+	private String userId;
+	private String userName;
+	
+	public UserState( GameEventController controller, String userId ) {
+		super( controller );
+		this.userId = userId;
+	}
+	
+	@Override
+	public void characters( char[] ch, int start, int length ) {
+		String value = new String( ch, start, length ).trim();
+		
+		if ( !"".equals( value ) ) {
+			this.userName = value;
+		}
+	}
+	
+	@Override
+	public void endElement( String uri, String localName, String qName ) {
+		if ( "user".equals( qName ) ) {
+			controller.addUser( userId, userName );
+			controller.setState( new ReadyState( controller ) );
+		}
+		else {
+			super.endElement( uri, localName, qName );
+		}
+	}
+}

--- a/axp/org/axp/state/states/UserState.java
+++ b/axp/org/axp/state/states/UserState.java
@@ -3,6 +3,11 @@ package org.axp.state.states;
 import org.axp.state.GameEventController;
 import org.axp.state.XMLState;
 
+/**
+ * In this state we read in the user's name. We could extend this with some more data, in which case we'd
+ * want an actual <tt>User</tt> entity, but for now we just pass a plain {@link String} to the controller
+ * when we're done parsing. We then return to the {@link ReadyState}.
+ */
 public class UserState extends XMLState {
 	private String userId;
 	private String userName;

--- a/axp/org/axp/state/ui/ClientView.java
+++ b/axp/org/axp/state/ui/ClientView.java
@@ -1,0 +1,83 @@
+package org.axp.state.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.util.Observable;
+import java.util.Observer;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JScrollPane;
+
+import org.axp.state.GameEventController;
+import org.axp.state.entity.Game;
+
+public class ClientView extends JFrame implements Observer {
+	private static final long serialVersionUID = -8864927050557607120L;
+	
+	private JLabel status = new JLabel( "Connecting..." );
+	private JList<String> userList = new JList<>();
+	private JList<Game> gameList = new JList<>();
+	private JLabel parseState = new JLabel();
+	
+	public ClientView( GameEventController controller ) {
+		super( "Dashboard" );
+		setDefaultCloseOperation( JFrame.EXIT_ON_CLOSE );
+		
+		this.userList.setEnabled( false );
+		this.gameList.setEnabled( false );
+		this.gameList.setCellRenderer( new GameCellRenderer() );
+		this.parseState.setFont( this.parseState.getFont().deriveFont( Font.PLAIN ) );
+		this.parseState.setForeground( Color.DARK_GRAY );
+		
+		Container pane = getContentPane();
+		pane.setLayout( new BorderLayout() );
+		
+		pane.add( this.status, BorderLayout.NORTH );
+		pane.add( wrap( this.userList ), BorderLayout.WEST );
+		pane.add( wrap( this.gameList ), BorderLayout.EAST );
+		pane.add( this.parseState, BorderLayout.SOUTH );
+		
+		pack();
+		
+		controller.addObserver( this );
+	}
+	
+	private static JScrollPane wrap( JList<?> list ) {
+		JScrollPane listScroller = new JScrollPane( list );
+		listScroller.setPreferredSize( new Dimension( 200, 200 ) );
+		return listScroller;
+	}
+
+	@Override
+	public void update( Observable o, Object change ) {
+		if ( "FINISHED".equals( change ) ) {
+			System.exit( 0 );
+		}
+		else if ( "DISCONNECTED".equals( change ) ) {
+			this.userList.setEnabled( false );
+			this.gameList.setEnabled( false );
+			this.status.setText( "Disconnected" );
+		}
+		else if ( "CONNECTED".equals( change ) ) {
+			this.userList.setEnabled( true );
+			this.gameList.setEnabled( true );
+			this.status.setText( "Connected" );
+		}
+		else if ( "USERS".equals( change ) ) {
+			GameEventController controller = (GameEventController) o;
+			this.userList.setListData( controller.getUserList() );
+		}
+		else if ( "GAMES".equals( change ) ) {
+			GameEventController controller = (GameEventController) o;
+			this.gameList.setListData( controller.getGameList() );
+		}
+		else if ( change != null && change.toString().startsWith( "STATE:" ) ) {
+			this.parseState.setText( change.toString().substring( "STATE:".length() ) );
+		}
+	}
+}

--- a/axp/org/axp/state/ui/ClientView.java
+++ b/axp/org/axp/state/ui/ClientView.java
@@ -16,6 +16,9 @@ import javax.swing.JScrollPane;
 import org.axp.state.GameEventController;
 import org.axp.state.entity.Game;
 
+/**
+ * Just a boring UI class. It observes the {@link GameEventController} and refreshes when necessary.
+ */
 public class ClientView extends JFrame implements Observer {
 	private static final long serialVersionUID = -8864927050557607120L;
 	

--- a/axp/org/axp/state/ui/GameCellRenderer.java
+++ b/axp/org/axp/state/ui/GameCellRenderer.java
@@ -9,6 +9,11 @@ import javax.swing.ListCellRenderer;
 
 import org.axp.state.entity.Game;
 
+/**
+ * Another boring UI class -- this renders games in multiline HTML.
+ * 
+ * (An example of the adaptor pattern, though, for those keeping score...)
+ */
 public class GameCellRenderer implements ListCellRenderer<Game> {
 	private static final Color ALICE_BLUE = new Color( 0xf0f8ff );
 	

--- a/axp/org/axp/state/ui/GameCellRenderer.java
+++ b/axp/org/axp/state/ui/GameCellRenderer.java
@@ -17,12 +17,24 @@ public class GameCellRenderer implements ListCellRenderer<Game> {
 	public static String toHtml( Game g ) {
 		StringBuilder sb = new StringBuilder( "<html>" ).append( g.getGameType() );
 		
+		if ( g.isFinished() ) {
+			sb.append( "<i>" ).append( " - COMPLETE" );
+		}
+		
 		for ( String p : g.getPlayers() ) {
 			sb.append( "<br>&nbsp;&nbsp;" ).append( p );
+			
+			if ( p.equals( g.getWinner() ) ) {
+				sb.append( " - WINNER" );
+			}
 		}
 		
 		for ( String rule : g.getRules() ) {
 			sb.append( "<br>&nbsp;&nbsp;" ).append( rule );
+		}
+		
+		if ( g.isFinished() ) {
+			sb.append( "</i>" );
 		}
 		
 		return sb.append( "</html>" ).toString();
@@ -30,10 +42,10 @@ public class GameCellRenderer implements ListCellRenderer<Game> {
 
 	@Override
 	public Component getListCellRendererComponent( JList<? extends Game> list,
-			Game value, int index, boolean isSelected, boolean cellHasFocus ) {
+			Game game, int index, boolean isSelected, boolean cellHasFocus ) {
 		
-		Component label = baseRenderer.getListCellRendererComponent( list, toHtml( value ), index, isSelected, cellHasFocus );
-		
+		Component label = baseRenderer.getListCellRendererComponent( list, toHtml( game ), index, isSelected, cellHasFocus );
+
 		if ( !isSelected && label.isEnabled() && ( index % 2 == 1 ) ) {
 			label.setBackground( ALICE_BLUE );
 		}

--- a/axp/org/axp/state/ui/GameCellRenderer.java
+++ b/axp/org/axp/state/ui/GameCellRenderer.java
@@ -1,0 +1,43 @@
+package org.axp.state.ui;
+
+import java.awt.Color;
+import java.awt.Component;
+
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
+import org.axp.state.entity.Game;
+
+public class GameCellRenderer implements ListCellRenderer<Game> {
+	private static final Color ALICE_BLUE = new Color( 0xf0f8ff );
+	
+	private DefaultListCellRenderer baseRenderer = new DefaultListCellRenderer();
+	
+	public static String toHtml( Game g ) {
+		StringBuilder sb = new StringBuilder( "<html>" ).append( g.getGameType() );
+		
+		for ( String p : g.getPlayers() ) {
+			sb.append( "<br>&nbsp;&nbsp;" ).append( p );
+		}
+		
+		for ( String rule : g.getRules() ) {
+			sb.append( "<br>&nbsp;&nbsp;" ).append( rule );
+		}
+		
+		return sb.append( "</html>" ).toString();
+	}
+
+	@Override
+	public Component getListCellRendererComponent( JList<? extends Game> list,
+			Game value, int index, boolean isSelected, boolean cellHasFocus ) {
+		
+		Component label = baseRenderer.getListCellRendererComponent( list, toHtml( value ), index, isSelected, cellHasFocus );
+		
+		if ( !isSelected && label.isEnabled() && ( index % 2 == 1 ) ) {
+			label.setBackground( ALICE_BLUE );
+		}
+		
+		return label;
+	}
+}


### PR DESCRIPTION
This solution uses the State pattern to build a better SAX parser. We have a situation where a server maintains a list of games and players, and reports it to the client via a continuous XML stream. (OK, that's probably terrible client-server design, but whatever.)

As the client receives this information from the server, it pops into various parse states for users and games.

My initial concept was to have a single `XMLReader` object as the context, and then have various `DefaultHandler` classes as the state classes, using `setContentHandler` as the state-switching method.

In practice I needed to do some extra work to get these objects to conform to the state pattern. My context class is `GameEventController`, which wraps the reader object and contains extra methods to notify the UI layer and (theoretically) to execute business logic. My abstract state is `XMLState`, which extends `DefaultHandler` and has a reference to the context object.

Note that I've avoided the approach taken in the book, where each state is held as a member field by the context. This breaks the open-closed principle in my opinion. Instead I construct a new state object each time I change state. That's somewhat more "pure", but obviously results in more object references.

Perhaps the ideal solution would be to break `GameEventController` into two parts; one which simply maintains a collection of available states, and one which handles the actual business logic. That would be better separation of concerns.