### PR TITLE
axp - Chapter 11 - The Proxy Pattern: Dynamic Proxy

### DIFF
--- a/axp-test/org/axp/proxy/dynamic/changelog/ChangeLogProxyTest.java
+++ b/axp-test/org/axp/proxy/dynamic/changelog/ChangeLogProxyTest.java
@@ -1,0 +1,156 @@
+package org.axp.proxy.dynamic.changelog;
+
+import java.util.HashMap;
+import java.util.Iterator;
+
+import org.axp.proxy.dynamic.PrivilegeLevelsInvocationHandler;
+import org.axp.proxy.dynamic.User;
+import org.axp.proxy.dynamic.changelog.ChangeLog;
+import org.axp.proxy.dynamic.changelog.ChangeLogEntry;
+import org.axp.proxy.dynamic.changelog.SimpleChangeLog;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ChangeLogProxyTest {
+	public User noelNoaccess = new ChangeLogUser( "noel", ChangeLogUser.LEVEL_NOACCESS );
+	public User ritaReadaccess = new ChangeLogUser( "rita", ChangeLogUser.LEVEL_READ );
+	public User aparnaAppendaccess = new ChangeLogUser( "aparna", ChangeLogUser.LEVEL_APPEND );
+	public User chadChangeaccess = new ChangeLogUser( "chad", ChangeLogUser.LEVEL_CHANGE );
+	
+	private User[] allUsers = new User[] { noelNoaccess, ritaReadaccess, aparnaAppendaccess, chadChangeaccess };
+	private HashMap<User, ChangeLog> accessPoints = new HashMap<>( 4 );
+	
+	@Before
+	public void setup() {
+		SimpleChangeLog actualChangeLog = new SimpleChangeLog();
+		actualChangeLog.addEntry( "Reticulated splines", aparnaAppendaccess );
+		
+		for ( User user : allUsers ) {
+			accessPoints.put( user, PrivilegeLevelsInvocationHandler.getProxy( actualChangeLog, user ) );
+		}
+	}
+	
+	@Test( expected = IllegalAccessException.class )
+	public void testIterateNoaccess() throws IllegalAccessException {
+		accessPoints.get( noelNoaccess ).iterator();
+	}
+	
+	private void testIterateAccess( User user ) throws IllegalAccessException {
+		Iterator<ChangeLogEntry> entries = accessPoints.get( user ).iterator();
+		assertTrue( "No entries", entries.hasNext() );
+		ChangeLogEntry e = entries.next();
+		assertEquals( "User mismatch", aparnaAppendaccess, e.getUser() );
+		assertEquals( "Status mismatch", "Reticulated splines", e.getAction() );
+		assertNotNull( "Null time", e.getTime() );
+		assertFalse( "More entries than expected", entries.hasNext() );
+	}
+	
+	@Test
+	public void testIterateReadaccess() throws IllegalAccessException {
+		testIterateAccess( ritaReadaccess );
+	}
+	
+	@Test
+	public void testIterateAppendaccess() throws IllegalAccessException {
+		testIterateAccess( aparnaAppendaccess );
+	}
+	
+	@Test
+	public void testIterateChangeaccess() throws IllegalAccessException {
+		testIterateAccess( chadChangeaccess );
+	}
+	
+	@Test( expected = UnsupportedOperationException.class )
+	public void testIteratorIsReadOnly() throws IllegalAccessException {
+		Iterator<ChangeLogEntry> entries = accessPoints.get( chadChangeaccess ).iterator();
+		assertTrue( "No entries", entries.hasNext() );
+		entries.next();
+		entries.remove();
+	}
+	
+	@Test( expected = IllegalAccessException.class )
+	public void testAddEntry2Noaccess() throws IllegalAccessException {
+		accessPoints.get( noelNoaccess ).addEntry( "Do more stuff", noelNoaccess );
+	}
+	
+	@Test( expected = IllegalAccessException.class )
+	public void testAddEntry2Readaccess() throws IllegalAccessException {
+		accessPoints.get( ritaReadaccess ).addEntry( "Do more stuff", ritaReadaccess );
+	}
+	
+	@Test( expected = IllegalAccessException.class )
+	public void testAddEntry2Appendaccess() throws IllegalAccessException {
+		accessPoints.get( aparnaAppendaccess ).addEntry( "Do more stuff", aparnaAppendaccess );
+	}
+	
+	@Test
+	public void testAddEntry2Changeaccess() throws IllegalAccessException {
+		accessPoints.get( chadChangeaccess ).addEntry( "Do more stuff", chadChangeaccess );
+		Iterator<ChangeLogEntry> entries = accessPoints.get( chadChangeaccess ).iterator();
+		assertTrue( "No entries", entries.hasNext() );
+		assertNotNull( "First entry", entries.next() );
+		assertTrue( "Not enough entries", entries.hasNext() );
+		ChangeLogEntry e = entries.next();
+		assertEquals( "User mismatch", chadChangeaccess, e.getUser() );
+		assertEquals( "Status mismatch", "Do more stuff", e.getAction() );
+		assertNotNull( "Null time", e.getTime() );
+		assertFalse( "More entries than expected", entries.hasNext() );
+	}
+	
+	@Test( expected = IllegalAccessException.class )
+	public void testAddEntry1Noaccess() throws IllegalAccessException {
+		accessPoints.get( noelNoaccess ).addEntry( "Do more stuff", noelNoaccess );
+	}
+	
+	@Test( expected = IllegalAccessException.class )
+	public void testAddEntry1Readaccess() throws IllegalAccessException {
+		accessPoints.get( ritaReadaccess ).addEntry( "Do more stuff", ritaReadaccess );
+	}
+	
+	private void testAddEntry1Access( User user ) throws IllegalAccessException {
+		accessPoints.get( user ).addEntry( "Do more stuff" );
+		Iterator<ChangeLogEntry> entries = accessPoints.get( user ).iterator();
+		assertTrue( "No entries", entries.hasNext() );
+		assertNotNull( "First entry", entries.next() );
+		assertTrue( "Not enough entries", entries.hasNext() );
+		ChangeLogEntry e = entries.next();
+		assertEquals( "User mismatch", user, e.getUser() );
+		assertEquals( "Status mismatch", "Do more stuff", e.getAction() );
+		assertNotNull( "Null time", e.getTime() );
+		assertFalse( "More entries than expected", entries.hasNext() );
+	}
+	
+	@Test
+	public void testAddEntry1Appendaccess() throws IllegalAccessException {
+		testAddEntry1Access( aparnaAppendaccess );
+	}
+	
+	@Test
+	public void testAddEntry1Changeaccess() throws IllegalAccessException {
+		testAddEntry1Access( chadChangeaccess );
+	}
+	
+	@Test( expected = IllegalAccessException.class )
+	public void testClearNoaccess() throws IllegalAccessException {
+		accessPoints.get( noelNoaccess ).clear();
+	}
+	
+	@Test( expected = IllegalAccessException.class )
+	public void testClearReadaccess() throws IllegalAccessException {
+		accessPoints.get( ritaReadaccess ).clear();
+	}
+	
+	@Test( expected = IllegalAccessException.class )
+	public void testClearAppendaccess() throws IllegalAccessException {
+		accessPoints.get( aparnaAppendaccess ).clear();
+	}
+	
+	@Test
+	public void testClearChangeaccess() throws IllegalAccessException {
+		accessPoints.get( chadChangeaccess ).clear();
+		Iterator<ChangeLogEntry> entries = accessPoints.get( chadChangeaccess ).iterator();
+		assertFalse( "Expected no entries", entries.hasNext() );
+	}
+}

--- a/axp/org/axp/proxy/dynamic/AccessCheck.java
+++ b/axp/org/axp/proxy/dynamic/AccessCheck.java
@@ -1,0 +1,15 @@
+package org.axp.proxy.dynamic;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that specifies the minimum access level required to execute a specific method.
+ */
+@Target( ElementType.METHOD )
+@Retention( RetentionPolicy.RUNTIME )
+public @interface AccessCheck {
+	int value();
+}

--- a/axp/org/axp/proxy/dynamic/AddUserParam.java
+++ b/axp/org/axp/proxy/dynamic/AddUserParam.java
@@ -1,0 +1,16 @@
+package org.axp.proxy.dynamic;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Optional annotation denoting that rather than executing the standard version of a method, the invocation
+ * handler should execute a method with an additional {@link User} as the final parameter
+ */
+@Target( ElementType.METHOD )
+@Retention( RetentionPolicy.RUNTIME )
+public @interface AddUserParam {
+
+}

--- a/axp/org/axp/proxy/dynamic/PrivilegeLevelsInvocationHandler.java
+++ b/axp/org/axp/proxy/dynamic/PrivilegeLevelsInvocationHandler.java
@@ -1,0 +1,82 @@
+package org.axp.proxy.dynamic;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.axp.proxy.dynamic.changelog.SimpleChangeLog;
+
+/**
+ * An invocation handler which restricts access to the target's methods based on the privilege level of
+ * a particular user, matching them against the {@link AccessCheck} annotations on the target interface.
+ * 
+ * This handler can also automatically add in the user as an extra parameter in certain method calls, if
+ * that method is annotated with {@link AddUserParam}.
+ *
+ * @param <T> the interface which you wish the proxy to conform to.
+ */
+public class PrivilegeLevelsInvocationHandler<T> implements InvocationHandler {
+	private T invocationTarget;
+	private User user;
+	
+	/**
+	 * Create a new invocation handler. Note that instead of calling this directly, you'll
+	 * usually want to call {@link #getProxy(Class, Object, User)}.
+	 * 
+	 * @param invocationTarget the unprotected class we want to invoke methods on
+	 * @param user the user invoking the methods
+	 */
+	protected PrivilegeLevelsInvocationHandler( T invocationTarget, User user ) {
+		this.invocationTarget = invocationTarget;
+		this.user = user;
+	}
+	
+	/*
+	 * Invoke the correct method on the target, based on the annotations on the interface and the privilege
+	 * level of the user.
+	 */
+	@Override
+	public Object invoke( Object proxy, Method method, Object[] args ) throws Throwable {
+		try {
+			AccessCheck check = method.getAnnotation( AccessCheck.class );
+			
+			if ( check == null ) {
+				throw new IllegalAccessException( "Unknown access level for method '#" + method.getName() + '\'' );
+			}
+			else if ( user.getPrivilegeLevel() < check.value() ) {
+				throw new IllegalAccessException( "User's access level is too low for method '#" + method.getName() + '\'' );
+			}
+			
+			if ( method.getAnnotation( AddUserParam.class ) != null ) {
+				Class<?>[] paramTypes = ArrayUtils.add( method.getParameterTypes(), User.class );
+				Object[] arguments = ArrayUtils.add( args, this.user );
+				
+				Method actualMethod = SimpleChangeLog.class.getMethod( method.getName(), paramTypes );
+				return actualMethod.invoke( this.invocationTarget, arguments );
+			}
+			
+			return method.invoke( this.invocationTarget, args );
+		}
+		catch ( InvocationTargetException e ) {
+			throw e.getCause();
+		}
+	}
+	
+	/**
+	 * Construct a new proxy to an invocation target
+	 * 
+	 * @param invocationTarget the unprotected class we want to invoke methods on
+	 * @param user the user invoking the methods
+	 * @return a proxy object which conforms to the same interface as the target, but only permits certain method calls
+	 * based on the user's privilege level
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T getProxy( T invocationTarget, User user ) {
+		return (T) Proxy.newProxyInstance( 
+				invocationTarget.getClass().getClassLoader(),
+				invocationTarget.getClass().getInterfaces(),
+				new PrivilegeLevelsInvocationHandler<T>( invocationTarget, user ) );
+	}
+}

--- a/axp/org/axp/proxy/dynamic/User.java
+++ b/axp/org/axp/proxy/dynamic/User.java
@@ -1,0 +1,16 @@
+package org.axp.proxy.dynamic;
+
+/**
+ * Abstract user class with a simple integer privilege level (larger = better)
+ */
+public abstract class User {
+	private int privLevel;
+	
+	public User( int privLevel ) {
+		this.privLevel = privLevel;
+	}
+	
+	public int getPrivilegeLevel() {
+		return this.privLevel;
+	}
+}

--- a/axp/org/axp/proxy/dynamic/changelog/ChangeLog.java
+++ b/axp/org/axp/proxy/dynamic/changelog/ChangeLog.java
@@ -1,0 +1,51 @@
+package org.axp.proxy.dynamic.changelog;
+
+import java.util.Iterator;
+
+import org.axp.proxy.dynamic.AccessCheck;
+import org.axp.proxy.dynamic.AddUserParam;
+import org.axp.proxy.dynamic.User;
+
+/**
+ * A system change log, with methods to read existing entries, add new ones, or clear.
+ */
+public interface ChangeLog {
+	/**
+	 * Iterate over existing entries in the log
+	 * 
+	 * @return a read-only iterator
+	 * @throws IllegalAccessException if the user does not have LEVEL_READ access
+	 */
+	@AccessCheck(ChangeLogUser.LEVEL_READ)
+	public Iterator<ChangeLogEntry> iterator() throws IllegalAccessException;
+	
+	/**
+	 * Add a new item to the log, recording yourself as the user. (Under the hood, a call to this method will be redirected
+	 * to {@link #addEntry(String, User)}.) 
+	 * 
+	 * @param action a short description of the action the user performed
+	 * @throws IllegalAccessException if the user does not have LEVEL_APPEND access, or if the method was invoked directly
+	 *   on the concrete implementation
+	 */
+	@AddUserParam
+	@AccessCheck(ChangeLogUser.LEVEL_APPEND)
+	public void addEntry( String action ) throws IllegalAccessException;
+	
+	/**
+	 * Add a new item to the log, recording any user. This requires a higher privilege level than {@link #addEntry(String)}.
+	 * 
+	 * @param action a short description of the action the user performed
+	 * @param user the user who performed the action
+	 * @throws IllegalAccessException if the <em>calling</em> user does not have LEVEL_CHANGE access
+	 */
+	@AccessCheck(ChangeLogUser.LEVEL_CHANGE)
+	public void addEntry( String action, User user ) throws IllegalAccessException;
+	
+	/**
+	 * Clear the log
+	 * 
+	 * @throws IllegalAccessException if the user does not have LEVEL_CHANGE access
+	 */
+	@AccessCheck(ChangeLogUser.LEVEL_CHANGE)
+	public void clear() throws IllegalAccessException;
+}

--- a/axp/org/axp/proxy/dynamic/changelog/ChangeLogEntry.java
+++ b/axp/org/axp/proxy/dynamic/changelog/ChangeLogEntry.java
@@ -1,0 +1,32 @@
+package org.axp.proxy.dynamic.changelog;
+
+import java.util.Date;
+
+import org.axp.proxy.dynamic.User;
+
+/**
+ * A single entry on the system change log
+ */
+public class ChangeLogEntry {
+	private final Date time;
+	private final User user;
+	private final String action;
+	
+	public ChangeLogEntry( Date time, User user, String action ) {
+		this.time = time;
+		this.user = user;
+		this.action = action;
+	}
+	
+	public Date getTime() {
+		return (Date) this.time.clone();
+	}
+	
+	public User getUser() {
+		return this.user;
+	}
+	
+	public String getAction() {
+		return this.action;
+	}
+}

--- a/axp/org/axp/proxy/dynamic/changelog/ChangeLogUser.java
+++ b/axp/org/axp/proxy/dynamic/changelog/ChangeLogUser.java
@@ -1,0 +1,24 @@
+package org.axp.proxy.dynamic.changelog;
+
+import org.axp.proxy.dynamic.User;
+
+/**
+ * A user of the system change log
+ */
+public class ChangeLogUser extends User {
+	public static final int LEVEL_NOACCESS = 0;
+	public static final int LEVEL_READ = 1;
+	public static final int LEVEL_APPEND = 2;
+	public static final int LEVEL_CHANGE = 3;
+	
+	private final String userName;
+	
+	public ChangeLogUser( String userName, int privLevel ) {
+		super( privLevel );
+		this.userName = userName;
+	}
+	
+	public String toString() {
+		return this.userName;
+	}
+}

--- a/axp/org/axp/proxy/dynamic/changelog/SimpleChangeLog.java
+++ b/axp/org/axp/proxy/dynamic/changelog/SimpleChangeLog.java
@@ -1,0 +1,32 @@
+package org.axp.proxy.dynamic.changelog;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.axp.proxy.dynamic.User;
+
+/**
+ * The concrete implementation of the system change log.
+ */
+public class SimpleChangeLog implements ChangeLog {
+	private ArrayList<ChangeLogEntry> entries = new ArrayList<>();
+
+	public Iterator<ChangeLogEntry> iterator() {
+		return Collections.unmodifiableList( this.entries ).iterator();
+	}
+
+	public void addEntry( String action ) throws IllegalAccessException {
+		// This method cannot be called directly, but only through the invocation handler
+		throw new IllegalAccessException( "Can't add entry without user" );
+	}
+	
+	public void addEntry( String action, User user ) {
+		this.entries.add( new ChangeLogEntry( Calendar.getInstance().getTime(), user, action ) );
+	}
+	
+	public void clear() {
+		this.entries.clear();
+	}
+}


### PR DESCRIPTION
Dynamic proxy pattern to allow or disallow access based on user privilege level. This is fully generic; it only requires that the class conforms to an interface with appropriate method annotations.

This has a bonus feature, harnessing the dark powers :smiling_imp: of reflection: we can specify that certain method calls are delegated, adding in the user themself as an extra parameter.

To show it in action, I've created a very simple system change log class, allowing users to see other people's actions, and record actions they have performed. We use the delegation trick to prevent users recording actions against some other user. Users with higher privilege levels can, however, record other users' actions, as well as being able to clear the changelog.

Scroll down to the interface, `ChangeLog.java`, to see all the changelog methods annotated with appropriate privilege levels. Then go to `PrivilegeLevelsInvocationHandler.java` to see how the sausages are made. :scream: