### PR TITLE
axp - Appendix A - Leftover Patterns: Visitor

### DIFF
--- a/axp-test/org/axp/visitor/VisitorTest.java
+++ b/axp-test/org/axp/visitor/VisitorTest.java
@@ -1,0 +1,79 @@
+package org.axp.visitor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+
+import org.axp.composite.Category;
+import org.axp.composite.Diet;
+import org.axp.composite.Organism;
+import org.axp.composite.OrganismTree;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test the {@link OrganismDietCollector} class, showing the power of the visitor pattern.
+ */
+public class VisitorTest {
+	protected static OrganismTree organisms;
+	
+	/**
+	 * Biologists may note that this tree does not contain a full set of biological ranks.
+	 * Oh well, it's just for testing.
+	 */
+	@Before
+	public void createOrganisms() {
+		VisitorTest.organisms =
+			new Category( "Organism" ).add(
+				new Category( "Animal" ).add(
+					new Category( "Mammal" ).add(
+						new Category( "Feline" ).add(
+							new Organism( "cat" )
+								.setAvgWeight( 4.0f )
+								.setDiet( Diet.CARNIVORE ),
+							new Organism( "lion" )
+								.setAvgWeight( 160.0f )
+								.setDiet( Diet.CARNIVORE )
+						),
+						new Category( "Rodent" ).add(
+							new Organism( "mouse" )
+								.setAvgWeight( 0.018f )
+								.setDiet( Diet.HERBIVORE )
+						)
+					),
+					new Category( "Bird" ).add(
+						new Category( "Waterfowl" ).add(
+							new Organism( "duck" )
+								.setAvgWeight( 1.15f )
+								.setDiet( Diet.OMNIVORE )
+						)
+					),
+					new Category( "Fish" ).add(
+						new Category( "Carp" ).add(
+							new Organism( "goldfish" )
+								.setDiet( Diet.OMNIVORE )
+						)
+					)
+					,
+					new Category( "Arthropod" ).add(
+						new Category( "Spider" ).add(
+							new Organism( "cellar spider" )
+								.setAvgWeight( 0.001f )
+								.setDiet( Diet.CARNIVORE )
+						)
+					)
+				)
+			);
+	}
+	
+	@Test
+	public void testFind() {
+		HashMap<Diet,Integer> diets = organisms.stream().collect( new OrganismDietCollector() );
+		assertNotNull( "Diets map", diets );
+		assertEquals( "Number of distinct diets", 3, diets.size() );
+		assertEquals( "Number of carnivores", new Integer( 3 ), diets.get( Diet.CARNIVORE ) );
+		assertEquals( "Number of herbivores", new Integer( 1 ), diets.get( Diet.HERBIVORE ) );
+		assertEquals( "Number of omnivores", new Integer( 2 ), diets.get( Diet.OMNIVORE ) );
+	}
+}

--- a/axp/org/axp/visitor/OrganismDietCollector.java
+++ b/axp/org/axp/visitor/OrganismDietCollector.java
@@ -1,0 +1,63 @@
+package org.axp.visitor;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import org.axp.composite.Diet;
+import org.axp.composite.Organism;
+import org.axp.composite.OrganismTree;
+
+/**
+ * A collector over a stream of organisms that records the numbers of herbivores, omnivores and carnivores
+ * 
+ * The stream in this case can be seen as a traverser, and the collector as a visitor
+ */
+public class OrganismDietCollector implements Collector<OrganismTree,HashMap<Diet,Integer>,HashMap<Diet,Integer>> {
+
+	/* Start with a fresh hashmap */
+	@Override
+	public Supplier<HashMap<Diet,Integer>> supplier() {
+		return HashMap<Diet,Integer>::new;
+	}
+
+	/* Keep a tally of each diet (only apply to actual organisms, not categories */
+	@Override
+	public BiConsumer<HashMap<Diet,Integer>, OrganismTree> accumulator() {
+		return (map, org) -> {
+			if ( org instanceof Organism ) {
+				Integer count = map.get( org.getDiet() );
+				map.put( org.getDiet(), ( count == null ) ? 1 : ++count );
+			}
+		};
+	}
+
+	/* Combine two hashmaps */
+	@Override
+	public BinaryOperator<HashMap<Diet,Integer>> combiner() {
+		return (map1, map2) -> {
+			map1.putAll( map2 );
+			return map1;
+		};
+	}
+
+	/* Nothing to do to finish */
+	@Override
+	public Function<HashMap<Diet,Integer>, HashMap<Diet, Integer>> finisher() {
+		return Function.identity();
+	}
+
+	/* Some hints as to how to use this collector */
+	@Override
+	public Set<Characteristics> characteristics() {
+		HashSet<Characteristics> crstcs = new HashSet<>( 2 );
+		crstcs.add( Characteristics.IDENTITY_FINISH );
+		crstcs.add( Characteristics.CONCURRENT );
+		return crstcs;
+	}
+}


### PR DESCRIPTION
We revisit (lol) the taxonomic tree we created for the Composite pattern. Since we used nifty Java 8 streams there, we should use the stream mechanism as an inbuilt Traverser. Then for our Visitor, we use a type of `Collector` object.

The specific Visitor I've written simply visits each organism, keeping a tally of the number of herbivores, omnivores and carnivores.